### PR TITLE
add: feature json schema

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,6 +2,16 @@
     "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
     "customizations": {
         "vscode": {
+            "settings": {
+                "json.schemas": [
+                    {
+                        "fileMatch": [
+                            "*/devcontainer-feature.json"
+                        ],
+                        "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json"
+                    }
+                ]
+            },
             "extensions": [
                 "mads-hartmann.bash-ide-vscode"
             ]


### PR DESCRIPTION
Without adding setting I am not getting type hints in VS Code when editing any `devcontainer-feature.json` files. 


Adding the schema setting I get no help...😃![Screen recording 2023-03-06 17 45 41](https://user-images.githubusercontent.com/16673615/223283221-ef07712e-ebea-4695-b90e-587f18359169.gif)

But without I get...😥![Screen recording 2023-03-06 17 46 08](https://user-images.githubusercontent.com/16673615/223283187-5ff731f0-64f2-4e3a-8632-efe832c17bc5.gif)
ing the schema to the settings I get 

Note: I'm not sure if the absence of schema for `devcontainer-feature.json` is something lacking in this template. Perhaps it's supposed to be implemented within one of the Remote Development VS Code Extensions. I do seem to be getting intelligence on `devcontainer.json` without using an explicit JSON schema setting this way.