### PR TITLE
Improve `test.sh` context

### DIFF
--- a/test/color/test.sh
+++ b/test/color/test.sh
@@ -33,12 +33,13 @@
 set -e
 
 # Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
 # Provides the 'check' and 'reportResults' commands.
 source dev-container-features-test-lib
 
 # Feature-specific tests
-# The 'check' command comes from the dev-container-features-test-lib.
-
+# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
+# check <LABEL> <cmd> [args...]
 check "validate favorite color" color | grep 'my favorite color is red'
 
 # Report result

--- a/test/hello/test.sh
+++ b/test/hello/test.sh
@@ -33,11 +33,13 @@
 set -e
 
 # Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
 # Provides the 'check' and 'reportResults' commands.
 source dev-container-features-test-lib
 
 # Feature-specific tests
-# The 'check' command comes from the dev-container-features-test-lib.
+# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
+# check <LABEL> <cmd> [args...]
 check "execute command" bash -c "hello | grep 'hey, $(whoami)!'"
 
 # Report results


### PR DESCRIPTION
I seeks to provide context on `test.sh` testing via `dev-container-features-test-lib`. 
Specifically in the `test.sh` files, what is the syntax of the `check` (and possibly `reportResults`) command?

My PR includes a [link](https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#check-label-cmd-args) and provides syntax. `check <LABEL> <cmd> [args...]`

However, there could be better ways (than this PR) to hint to people using this starter template about testing?🤔 Perhaps a README.md in the `test` dir?