### PR TITLE
feat: cache CLI install

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -21,6 +21,5 @@
         "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },
     "remoteUser": "node",
-    "onCreateCommand": "npm install -g @devcontainers/cli", // install in cache layer
-	"updateContentCommand": "npm update -g @devcontainers/cli" // update if new
+    "updateContentCommand": "npm install -g @devcontainers/cli"
 }

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -21,5 +21,6 @@
         "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },
     "remoteUser": "node",
-    "postCreateCommand": "npm install -g @devcontainers/cli"
+    "onCreateCommand": "npm install -g @devcontainers/cli", // install in cache layer
+	"updateContentCommand": "npm update -g @devcontainers/cli" // update if new
 }


### PR DESCRIPTION
Elevated install of `devcontainers` cli to earlier lifecycle scripts to enable caching. Cli install doesn't require any user specific's of `postCreateCommand`.

If PR is adopted, recommend similar change on `template-starter`