### PR TITLE
Update .devcontainer.json

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye",
     "customizations": {
         "vscode": {
             "settings": {


### PR DESCRIPTION
closes https://github.com/devcontainers/feature-starter/issues/55

Updates this repo's dev container config to the latest major version of the `javascript-node` image, as well as pin to an OS (per best practices).