### PR TITLE
ci: Fix git user settings in `release.yaml`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,8 +31,8 @@ jobs:
           set -e
           echo "Start."
           # Configure git and Push updates
-          git config --global user.email github-actions@github.com
-          git config --global user.name github-actions
+          git config --global user.email github-actions[bot]@users.noreply.github.com
+          git config --global user.name github-actions[bot]
           git config pull.rebase false
           branch=automated-documentation-update-$GITHUB_RUN_ID
           git checkout -b $branch


### PR DESCRIPTION
The current git user settings for the release workflow shows a "invalid email address" as the commit author (see: https://github.com/joshuanianji/devcontainer-features/blob/027ef80472bcb01ddd364f1496b2222a92d11577/src/terraform-cli-persistence/README.md).

This PR just changes the git email and user so we see the "github actions bot," based off of [this discussion](https://github.com/actions/checkout/discussions/479). This seems to work on my repo so far: [joshuanianji/devcontainer-features](https://github.com/joshuanianji/devcontainer-features)