### PR TITLE
Update github-actions[bot]'s email address

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           set -e
           echo "Start."
           # Configure git and Push updates
-          git config --global user.email github-actions[bot]@users.noreply.github.com
+          git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
           git config --global user.name github-actions[bot]
           git config pull.rebase false
           branch=automated-documentation-update-$GITHUB_RUN_ID


### PR DESCRIPTION
Perhaps the bot's email address is incorrect and not correctly identified as a GitHub Actions one by GitHub?

![image](https://github.com/devcontainers/feature-starter/assets/50911393/58d70076-6c38-47d3-9b1c-1e67b313f27a)
From https://github.com/rocker-org/devcontainer-features/graphs/contributors
